### PR TITLE
Add conditional check for existing Git tag creation

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -39,5 +39,9 @@ jobs:
 
       - name: Create Git Tag
         run: |
-          git tag v${{ steps.version-bump.outputs.version }}
-          git push origin v${{ steps.version-bump.outputs.version }}
+          if git rev-parse v${{ steps.version-bump.outputs.version }} >/dev/null 2>&1; then
+              echo "Tag v${{ steps.version-bump.outputs.version }} already exists. Skipping tag creation."
+          else
+              git tag v${{ steps.version-bump.outputs.version }}
+              git push origin v${{ steps.version-bump.outputs.version }}
+          fi


### PR DESCRIPTION
✨ Add conditional check for existing Git tag creation

Auto stash before checking out "origin/main" to help craft the commit message. This change adds a conditional check to prevent re-creating an existing Git tag during deployment.
✨ Add conditional check for existing Git tag creation

Add a conditional check to prevent re-creating an existing Git tag during deployment in the workflow file.
